### PR TITLE
Make containers compatible with docker-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN /bin/sed -i s/archive.ubuntu.com/se.archive.ubuntu.com/g /etc/apt/sources.li
 RUN apt-get -q update
 RUN apt-get install -y software-properties-common
 RUN apt-get -y upgrade
-RUN apt-get install -y cmake locales python2.7 python3 python3.7 git-core swig libyaml-dev libyaml-dev python-dev python3-dev python3.7-dev build-essential xsltproc libxml2-dev libxslt-dev libz-dev libssl-dev python-virtualenv python3-venv python3.7-venv wget automake libtool autoconf pkgconf sloccount xmlsec1
+RUN apt-get install -y cmake locales python2.7 python3 python3.7 git-core swig libyaml-dev libyaml-dev python-dev python3-dev python3.7-dev build-essential xsltproc libxml2-dev libxslt-dev libz-dev libssl-dev python-virtualenv python3-venv python3.7-venv wget automake libtool autoconf pkgconf sloccount xmlsec1 default-jdk-headless
 RUN apt-get clean
+RUN adduser --disabled-password --disabled-login --gecos jenkins jenkins
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -4,8 +4,9 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN /bin/sed -i s/deb.debian.org/ftp.se.debian.org/g /etc/apt/sources.list
 RUN apt-get -q update
 RUN apt-get -y upgrade
-RUN apt-get install -y locales git-core wget sloccount
+RUN apt-get install -y locales git-core wget sloccount default-jdk-headless
 RUN apt-get clean
+RUN adduser --disabled-password --disabled-login --gecos jenkins jenkins
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/golang/run.sh
+++ b/golang/run.sh
@@ -5,7 +5,7 @@ set -x
 
 ## Commands to run on container start
 # Allow tests to connect to containers as they where on localhost
-echo $(docker inspect -f '{{.NetworkSettings.Gateway}}' $(hostname)) localhost >> /etc/hosts
+echo "$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$(hostname)") localhost" >> /etc/hosts
 
 # CloudBees standard "wait for exec" command
 /bin/cat

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -4,8 +4,9 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN /bin/sed -i s/deb.debian.org/ftp.se.debian.org/g /etc/apt/sources.list
 RUN apt-get -q update
 RUN apt-get -y upgrade
-RUN apt-get install -y locales git-core wget sloccount
+RUN apt-get install -y locales git-core wget sloccount default-jdk-headless
 RUN apt-get clean
+RUN adduser --disabled-password --disabled-login --gecos jenkins jenkins
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/maven/run.sh
+++ b/maven/run.sh
@@ -5,7 +5,7 @@ set -x
 
 ## Commands to run on container start
 # Allow tests to connect to containers as they where on localhost
-echo $(docker inspect -f '{{.NetworkSettings.Gateway}}' $(hostname)) localhost >> /etc/hosts
+echo "$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$(hostname)") localhost" >> /etc/hosts
 
 # CloudBees standard "wait for exec" command
 /bin/cat

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -4,7 +4,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN /bin/sed -i s/deb.debian.org/ftp.se.debian.org/g /etc/apt/sources.list
 RUN apt-get -q update
 RUN apt-get -y upgrade
-RUN apt-get install -y locales git-core wget sloccount
+RUN apt-get install -y locales git-core wget sloccount default-jdk-headless
 # Dependencies for headless chrome
 RUN apt-get install -y \
     libpangocairo-1.0-0 \
@@ -23,6 +23,7 @@ RUN apt-get install -y \
     libatk1.0-0 \
     libgtk-3-0
 RUN apt-get clean
+RUN adduser --disabled-password --disabled-login --gecos jenkins jenkins
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/node/run.sh
+++ b/node/run.sh
@@ -5,7 +5,7 @@ set -x
 
 ## Commands to run on container start
 # Allow tests to connect to containers as they where on localhost
-echo $(docker inspect -f '{{.NetworkSettings.Gateway}}' $(hostname)) localhost >> /etc/hosts
+echo "$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$(hostname)") localhost" >> /etc/hosts
 
 # CloudBees standard "wait for exec" command
 /bin/cat

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ cp /etc/hosts /etc/hosts.bak && \
 sed '/localhost/ s/^#*/#/' /etc/hosts.bak > /etc/hosts && \
 rm /etc/hosts.bak
 # Allow tests to connect to containers as they where on localhost
-echo $(docker inspect -f '{{.NetworkSettings.Gateway}}' $(hostname)) localhost >> /etc/hosts
+echo "$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$(hostname)") localhost" >> /etc/hosts
 
 # CloudBees standard "wait for exec" command
 /bin/cat

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -5,8 +5,9 @@ RUN /bin/sed -i s/deb.debian.org/ftp.se.debian.org/g /etc/apt/sources.list
 RUN apt-get -q update
 RUN apt-get install -y software-properties-common
 RUN apt-get -y upgrade
-RUN apt-get install -y cmake locales python2.7 python3 git-core swig libyaml-dev libyaml-dev python-dev python3-dev build-essential xsltproc libxml2-dev libxslt-dev libz-dev libssl-dev python-virtualenv python3-venv wget automake libtool autoconf pkgconf sloccount xmlsec1
+RUN apt-get install -y cmake locales python2.7 python3 git-core swig libyaml-dev libyaml-dev python-dev python3-dev build-essential xsltproc libxml2-dev libxslt-dev libz-dev libssl-dev python-virtualenv python3-venv wget automake libtool autoconf pkgconf sloccount xmlsec1 default-jdk-headless
 RUN apt-get clean
+RUN adduser --disabled-password --disabled-login --gecos jenkins jenkins
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/xenial/run.sh
+++ b/xenial/run.sh
@@ -5,7 +5,7 @@ set -x
 
 ## Commands to run on container start
 # Allow tests to connect to containers as they where on localhost
-echo $(docker inspect -f '{{.NetworkSettings.Gateway}}' $(hostname)) localhost >> /etc/hosts
+echo "$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$(hostname)") localhost" >> /etc/hosts
 
 # CloudBees standard "wait for exec" command
 /bin/cat


### PR DESCRIPTION
This makes these containers compatible with being run as jenkins-agents
via docker-plugin, and fixes a bug with the localhost redirection hack
on modern docker versions.